### PR TITLE
Swap order of nan checks to allow histogram(:middle) to work with zero stdev arrays

### DIFF
--- a/lib/histogram.rb
+++ b/lib/histogram.rb
@@ -53,6 +53,7 @@ module Histogram
       opt = {:method => DEFAULT_QUARTILE_METHOD, :sorted => false}.merge( opts )
       srted = opt[:sorted] ? obj : obj.sort
       sz = srted.size
+      return 0 if sz == 1
       answer = 
         case opt[:method]
         when :tukey
@@ -72,6 +73,7 @@ module Histogram
 
     # finds median on a pre-sorted array
     def median(sorted)
+      return sorted[0] if sorted.size == 1
       (sorted[(sorted.size - 1) / 2] + sorted[sorted.size / 2]) / 2.0
     end
   end

--- a/spec/histogram_spec.rb
+++ b/spec/histogram_spec.rb
@@ -102,6 +102,10 @@ shared_examples 'something that can histogram' do
     bins, freq = obj6.histogram(:middle)
   end
 
+  it 'can handle an array of length 1' do
+    bins, freq = obj7.histogram(:middle)
+  end
+
 end
 
 describe Histogram do
@@ -112,7 +116,8 @@ describe Histogram do
     :obj3 => [1, 1, 2, 2, 3, 3, 4, 4, 4],
     :obj4 => [2, 2, 2, 2, 2, 4],
     :obj5 => [1,2,3,3,3,4,5,6,7,8],
-    :obj6 => [0,0,0,0,0]
+    :obj6 => [0,0,0,0,0],
+    :obj7 => [0]
   }
   data = tmp.each {|k,v| [k, v.map(&:to_f).extend(Histogram)] }
 


### PR DESCRIPTION
The check would set it to 1 if nbins was <= 0, and then try to check 1.nan? which failed because 1 is a Fixnum (not a float). Swapping the order fixes this.
