### PR TITLE
Check existence of the index of array.

### DIFF
--- a/lib/histogram.rb
+++ b/lib/histogram.rb
@@ -343,7 +343,7 @@ module Histogram
           if index == bins
             index -= 1
           end
-          _freqs[index] += height
+          _freqs[index] += height if _freqs[index]
         end
         _freqs
       end


### PR DESCRIPTION
Hello.
The below code sample throws the Exception because there is much bigger value(3424) in array than specified max value(2000).

```rb
require 'histogram/array'
values = [
  1113,
  789,
  319,
  3424,
  1166,
  1610,
  719,
]
values.histogram( 8, min: 0, max: 2000 )
  # NoMethodError: undefined method `+' for nil:NilClass
```

Simply, this problem could be avoided by checking the existence of index.
How do you think?